### PR TITLE
no initial confirmation and no force mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Minimal tool that keeps a single file two-way synced.
 
+Works with multiple agents and non-aligned timezones.
+
 ## Requirements
 
 ### Listener


### PR DESCRIPTION
Always allow the newest version to overwrite the counterpart instead of interactively asking at the initial comparison.